### PR TITLE
Module and Shell usage

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+'use strict';
+const zipFolderSync = require('./')
+const path = require('path')
+const args = process.argv.slice(2)
+const folder = path.join(process.cwd(), args[0])
+const outputFile = args[1] || 'output.zip'
+const ignores = args.slice(2) || ['.git']
+
+process.stdout.write(`Zipping ${outputFile}...`)
+
+zipFolderSync(folder, outputFile, ignores)

--- a/index.js
+++ b/index.js
@@ -5,17 +5,6 @@ const deasync = require('deasync')
 
 module.exports = zipFolderSync
 
-if (process.argv.length > 2) {
-  const args = process.argv.slice(2)
-  const folder = path.join(__dirname, args[0])
-  const outputFile = args[1] || 'output.zip'
-  const ignores = args.slice(2) || ['.git']
-
-  process.stdout.write(`Zipping ${outputFile}...`)
-
-  zipFolderSync(folder, outputFile, ignores)
-}
-
 function zipFolderSync (folder, outputFile, ignores) {
   folder = path.resolve(folder)
   outputFile = path.resolve(outputFile)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.4",
   "description": "zip a folder synchronously",
   "main": "index.js",
+  "bin": {
+    "folder-zip-sync": "cli.js"
+  },
   "dependencies": {
     "deasync": "^0.1.9",
     "yazl": "^2.4.2"


### PR DESCRIPTION
Hi Jonathan,

it was not possible to use the package as the module in the application which is started with 2> shell arguments, as `folder-zip-sync` assumes the arguments are for zipping, and start the zip process automatically, but they are not, they are for the main application purpose. So here we split the package so that it could be used as cli tool and also as a simple node module.

Best, Alex